### PR TITLE
set encoding to utf-8 because my xerox printer don't accept it

### DIFF
--- a/src/Ticketing/XPIF/XpifTicket.php
+++ b/src/Ticketing/XPIF/XpifTicket.php
@@ -56,7 +56,7 @@ class XpifTicket extends XpifBase
         $this->_populateCollection();
 
         //main domDocument
-        $mainDomDocument = new \DOMDocument();
+        $mainDomDocument = new \DOMDocument('1.0', 'UTF-8');
         $mainDomDocument->preserveWhiteSpace = true;
         $mainDomDocument->formatOutput = true;
         $docType = (new \DOMImplementation())->createDocumentType('xpif', '', $this->dtd_version);


### PR DESCRIPTION
on the xerox printer freeflow it did ignore the ticket, after breacking my head for a over a hour i fegured out its becouse it did not have set the xml encoding, so here is the fix